### PR TITLE
fix(render): hide invisible entities in hitboxes

### DIFF
--- a/src/main/java/top/fpsmaster/features/impl/render/Hitboxes.java
+++ b/src/main/java/top/fpsmaster/features/impl/render/Hitboxes.java
@@ -2,7 +2,6 @@ package top.fpsmaster.features.impl.render;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.AxisAlignedBB;
 import org.lwjgl.opengl.GL11;
 import top.fpsmaster.event.Subscribe;
@@ -60,7 +59,7 @@ public class Hitboxes extends Module {
             );
             IRenderManager renderManager = (IRenderManager) mc.getRenderManager();
             for (Entity entity : mc.theWorld.loadedEntityList) {
-                if (entity == mc.thePlayer || !(entity instanceof EntityPlayer) && entity.isInvisible()) {
+                if (entity == mc.thePlayer || entity.isInvisibleToPlayer(mc.thePlayer)) {
                     continue;
                 }
                 AxisAlignedBB bb = entity.getEntityBoundingBox()


### PR DESCRIPTION
修复 ```显示碰撞箱``` 功能会显示隐身玩家的问题