### PR TITLE
fix(keybinding): support mouse side buttons for toggle perspective

### DIFF
--- a/src/main/java/top/fpsmaster/forge/mixin/MixinMinecraft.java
+++ b/src/main/java/top/fpsmaster/forge/mixin/MixinMinecraft.java
@@ -166,10 +166,16 @@ public abstract class MixinMinecraft implements IMinecraft {
         EventDispatcher.dispatchEvent(new EventTick());
     }
 
-    // Ugly code
+    private boolean lastPerspectiveDown = false;
+    private boolean lastSmoothDown = false;
+
     @Inject(method = "runTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/settings/KeyBinding;isPressed()Z", ordinal = 3))
     public void chatVis(CallbackInfo ci) {
-        if (this.gameSettings.keyBindTogglePerspective.isPressed()) {
+        // Edge detection: isPressed works for keyboard, isKeyDown works for mouse side buttons
+        boolean perspectiveDown = this.gameSettings.keyBindTogglePerspective.isPressed()
+            || this.gameSettings.keyBindTogglePerspective.isKeyDown();
+        if (perspectiveDown && !lastPerspectiveDown) {
+            lastPerspectiveDown = true;
             ++this.gameSettings.thirdPersonView;
             if (this.gameSettings.thirdPersonView > 2) {
                 this.gameSettings.thirdPersonView = 0;
@@ -182,10 +188,17 @@ public abstract class MixinMinecraft implements IMinecraft {
             }
 
             this.renderGlobal.setDisplayListEntitiesDirty();
+        } else if (!perspectiveDown) {
+            lastPerspectiveDown = false;
         }
 
-        if (this.gameSettings.keyBindSmoothCamera.isPressed()) {
+        boolean smoothDown = this.gameSettings.keyBindSmoothCamera.isPressed()
+            || this.gameSettings.keyBindSmoothCamera.isKeyDown();
+        if (smoothDown && !lastSmoothDown) {
+            lastSmoothDown = true;
             this.gameSettings.smoothCamera = !this.gameSettings.smoothCamera;
+        } else if (!smoothDown) {
+            lastSmoothDown = false;
         }
     }
 


### PR DESCRIPTION
# 问题原因：
Minecraft 的 KeyBinding.isPressed() 只递增 pressTime（键盘事件驱动），鼠标事件调用
setKeyBindState() 改 pressed 但不递增 pressTime。所以侧键绑的视角切换键 isPressed() 永远返回 false。

## 修复方案：
在 chatVis 中改用边缘检测（上升沿检测），同时检查 isPressed()（键盘）和 isKeyDown()（鼠标侧键），确保不管用键盘还是鼠标按键都能触发