### PR TITLE
fix(keybinding): replace ordinal mixin with RETURN inject 

### DIFF
--- a/src/main/java/top/fpsmaster/forge/mixin/MixinMinecraft.java
+++ b/src/main/java/top/fpsmaster/forge/mixin/MixinMinecraft.java
@@ -166,16 +166,9 @@ public abstract class MixinMinecraft implements IMinecraft {
         EventDispatcher.dispatchEvent(new EventTick());
     }
 
-    private boolean lastPerspectiveDown = false;
-    private boolean lastSmoothDown = false;
-
-    @Inject(method = "runTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/settings/KeyBinding;isPressed()Z", ordinal = 3))
+    @Inject(method = "runTick", at = @At("RETURN"))
     public void chatVis(CallbackInfo ci) {
-        // Edge detection: isPressed works for keyboard, isKeyDown works for mouse side buttons
-        boolean perspectiveDown = this.gameSettings.keyBindTogglePerspective.isPressed()
-            || this.gameSettings.keyBindTogglePerspective.isKeyDown();
-        if (perspectiveDown && !lastPerspectiveDown) {
-            lastPerspectiveDown = true;
+        if (this.gameSettings.keyBindTogglePerspective.isPressed()) {
             ++this.gameSettings.thirdPersonView;
             if (this.gameSettings.thirdPersonView > 2) {
                 this.gameSettings.thirdPersonView = 0;
@@ -188,17 +181,10 @@ public abstract class MixinMinecraft implements IMinecraft {
             }
 
             this.renderGlobal.setDisplayListEntitiesDirty();
-        } else if (!perspectiveDown) {
-            lastPerspectiveDown = false;
         }
 
-        boolean smoothDown = this.gameSettings.keyBindSmoothCamera.isPressed()
-            || this.gameSettings.keyBindSmoothCamera.isKeyDown();
-        if (smoothDown && !lastSmoothDown) {
-            lastSmoothDown = true;
+        if (this.gameSettings.keyBindSmoothCamera.isPressed()) {
             this.gameSettings.smoothCamera = !this.gameSettings.smoothCamera;
-        } else if (!smoothDown) {
-            lastSmoothDown = false;
         }
     }
 


### PR DESCRIPTION
for reliabe side mouse button detection
旧 ordinal=3 要求在 runTick() 中第 4 个 isPressed() 调用点注入。按住 LMB/RMB 时，Minecraft
会走不同的代码路径（左键攻击循环、右键交互），isPressed() 的总调用次数变了，ordinal 3
就会落在不存在/错误的位置上 → 代码不执行。