### PR TITLE
feat(hud): 增加右下角拖拽把手，并把拖拽状态从字符串改为引用

### DIFF
--- a/src/main/java/top/fpsmaster/ui/custom/Component.java
+++ b/src/main/java/top/fpsmaster/ui/custom/Component.java
@@ -24,9 +24,21 @@ import java.awt.*;
 public class Component {
     private static final Color STENCIL_MASK_COLOR = new Color(255, 255, 255, 255);
 
+    private static final float MIN_SCALE = 0.5f;
+    private static final float MAX_SCALE = 4.5f;
+    private static final float HANDLE_SIZE = 6f;
+    /** Cursor travel, in screen pixels, needed to change the scale by 1x. */
+    private static final float RESIZE_SENSITIVITY = 1f / 60f;
+
     private float dragX = 0f;
 
     private float dragY = 0f;
+
+    private float resizeStartScale = 1f;
+
+    private int resizeStartMouseX;
+
+    private int resizeStartMouseY;
 
     public InterfaceModule mod;
 
@@ -197,18 +209,24 @@ public class Component {
         if ((Utility.mc.currentScreen instanceof GuiChat || Utility.mc.currentScreen instanceof MainPanel)) {
             float scaledWidth = width * scale;
             float scaledHeight = height * scale;
-            boolean drag = FPSMaster.componentsManager.dragLock.equals(mod.name);
+            ComponentsManager manager = FPSMaster.componentsManager;
+            boolean drag = manager.dragTarget == this;
+            boolean hovered = Hover.is(rX, rY, scaledWidth, scaledHeight, mouseX, mouseY);
+            boolean overHandle = allowScale && isOverResizeHandle(rX, rY, scaledWidth, scaledHeight, mouseX, mouseY);
 
-            alpha = (float) ((Hover.is(rX, rY, scaledWidth, scaledHeight, mouseX, mouseY) || drag) ?
+            alpha = (float) ((hovered || overHandle || drag) ?
                     AnimMath.base(alpha, 1f, 0.2f) : AnimMath.base(alpha, 0.0f, 0.2f));
 
             Rects.fill(rX - 2, rY - 2, scaledWidth + 4, scaledHeight + 4, new Color(0, 0, 0, (int) (alpha * 80)));
             draw(rX, rY);
             GL11.glColor4f(1, 1, 1, 1);
-            if (!Mouse.isButtonDown(0)) {
-                FPSMaster.componentsManager.dragLock = "";
+
+            if (alpha > 0.01f && hasResizeHandle(scaledWidth, scaledHeight)) {
+                drawResizeHandle(rX, rY, scaledWidth, scaledHeight,
+                        overHandle || (drag && manager.dragMode == ComponentsManager.DragMode.RESIZE));
             }
-            if (Hover.is(rX, rY, scaledWidth, scaledHeight, mouseX, mouseY) || drag) {
+
+            if (hovered || overHandle || drag) {
                 if (Utility.mc.currentScreen instanceof MainPanel && ((MainPanel) Utility.mc.currentScreen).hasPointerCapture())
                     return;
                 if (allowScale && ClientSettings.isZoomBindDown()) {
@@ -216,19 +234,30 @@ public class Component {
                     if (dWheel > 0) scaleUp();
                     else if (dWheel < 0) scaleDown();
                 }
-                FPSMaster.fontManager.s14.drawString(FPSMaster.i18n.get(mod.name.toLowerCase()) + " " + (scale * 10) / 10f + "x", rX, rY - 10, new Color(255, 255, 255, (int) (alpha * 255)).getRGB());
+                FPSMaster.fontManager.s14.drawString(FPSMaster.i18n.get(mod.name.toLowerCase()) + " " + Math.round(scale * 10) / 10f + "x", rX, rY - 10, new Color(255, 255, 255, (int) (alpha * 255)).getRGB());
 
                 if (!Mouse.isButtonDown(0)) return;
 
-                if (!drag && FPSMaster.componentsManager.dragLock.isEmpty()) {
-                    dragX = mouseX - rX;
-                    dragY = mouseY - rY;
-                    FPSMaster.componentsManager.dragLock = mod.name;
+                if (manager.dragTarget == null) {
+                    manager.dragTarget = this;
+                    if (overHandle) {
+                        manager.dragMode = ComponentsManager.DragMode.RESIZE;
+                        resizeStartScale = scale;
+                        resizeStartMouseX = mouseX;
+                        resizeStartMouseY = mouseY;
+                    } else {
+                        manager.dragMode = ComponentsManager.DragMode.MOVE;
+                        dragX = mouseX - rX;
+                        dragY = mouseY - rY;
+                    }
                 }
 
-                if (FPSMaster.componentsManager.dragLock.equals(mod.name)) {
-                    move(mouseX, mouseY);
-                    FPSMaster.componentsManager.dragLock = mod.name;
+                if (manager.dragTarget == this) {
+                    if (manager.dragMode == ComponentsManager.DragMode.RESIZE) {
+                        resizeTo(mouseX, mouseY);
+                    } else {
+                        move(mouseX, mouseY);
+                    }
                 }
             }
         } else {
@@ -237,11 +266,51 @@ public class Component {
     }
 
     public void scaleUp() {
-        if (scale < 4.5f) scale = (int) (scale * 10 + 1) / 10f;
+        if (scale < MAX_SCALE) scale = (int) (scale * 10 + 1) / 10f;
     }
 
     public void scaleDown() {
-        if (scale > 0.5f) scale = (int) (scale * 10 - 1) / 10f;
+        if (scale > MIN_SCALE) scale = (int) (scale * 10 - 1) / 10f;
+    }
+
+    /**
+     * The handle is suppressed on components smaller than this, where its grab area would swallow most
+     * of the body and leave no room to start a move.
+     */
+    private boolean hasResizeHandle(float scaledWidth, float scaledHeight) {
+        return allowScale && scaledWidth >= HANDLE_SIZE * 3f && scaledHeight >= HANDLE_SIZE * 3f;
+    }
+
+    /** Bottom-right corner box the user grabs to resize. Sized in screen pixels, deliberately not
+     *  scaled — otherwise a component shrunk to 0.5x would have a handle too small to hit. */
+    private boolean isOverResizeHandle(float rX, float rY, float scaledWidth, float scaledHeight, int mouseX, int mouseY) {
+        if (!hasResizeHandle(scaledWidth, scaledHeight)) {
+            return false;
+        }
+        return Hover.is(rX + scaledWidth - HANDLE_SIZE, rY + scaledHeight - HANDLE_SIZE,
+                HANDLE_SIZE * 2f, HANDLE_SIZE * 2f, mouseX, mouseY);
+    }
+
+    private void drawResizeHandle(float rX, float rY, float scaledWidth, float scaledHeight, boolean active) {
+        float handleX = rX + scaledWidth - HANDLE_SIZE;
+        float handleY = rY + scaledHeight - HANDLE_SIZE;
+        int shade = (int) (alpha * (active ? 255 : 160));
+        Rects.rounded(handleX, handleY, HANDLE_SIZE, HANDLE_SIZE, 2, new Color(255, 255, 255, shade).getRGB());
+        Rects.rounded(handleX + 1f, handleY + 1f, HANDLE_SIZE - 2f, HANDLE_SIZE - 2f, 1,
+                new Color(0, 0, 0, (int) (alpha * 140)).getRGB());
+    }
+
+    /**
+     * Resizes from how far the cursor has travelled since the grab, not from its distance to the
+     * component's origin: for right/bottom-anchored components the origin itself moves as the scale
+     * changes, which would feed back into the next frame's delta and run away.
+     */
+    private void resizeTo(int mouseX, int mouseY) {
+        float delta = ((mouseX - resizeStartMouseX) + (mouseY - resizeStartMouseY)) / 2f;
+        float target = resizeStartScale + delta * RESIZE_SENSITIVITY;
+        // Quantise to the same 0.1 steps the scroll wheel uses so both paths agree.
+        target = Math.round(target * 10f) / 10f;
+        scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, target));
     }
 
     private void move(int x, int y) {

--- a/src/main/java/top/fpsmaster/ui/custom/ComponentsManager.java
+++ b/src/main/java/top/fpsmaster/ui/custom/ComponentsManager.java
@@ -15,8 +15,22 @@ public class ComponentsManager {
     // List to hold all components
     public final ArrayList<Component> components = new ArrayList<>();
 
-    // Variable to track drag lock state
-    public String dragLock = "";
+    /** What a drag gesture is doing to {@link #dragTarget}. */
+    public enum DragMode {
+        MOVE,
+        RESIZE
+    }
+
+    /**
+     * The component currently being dragged, or {@code null}. Previously this was the module's name as
+     * a String, which cost a string compare per component per frame and could collide when a component
+     * fell back to a synthesised module. More importantly the "mouse released → unlock" rule was
+     * evaluated inside each component's own display(), so if every HUD element happened to be hidden
+     * mid-drag the lock was never cleared and nothing could be dragged again.
+     */
+    public Component dragTarget;
+
+    public DragMode dragMode = DragMode.MOVE;
 
     // Initialize all components
     public void init() {
@@ -142,6 +156,12 @@ public class ComponentsManager {
         mouseY = mouseY * scaleFactor / 2;
 
         GuiScale.fixScale();
+
+        // Releasing the button ends any drag — decided once per frame here rather than inside each
+        // component, so it holds even when no component is visible to run the check.
+        if (!org.lwjgl.input.Mouse.isButtonDown(0)) {
+            dragTarget = null;
+        }
 
         // Draw all components that should be displayed
         int finalMouseX = mouseX;


### PR DESCRIPTION
> 基于 #168（其又基于 #167），请按 167 → 168 → 本 PR 的顺序合并。

## 拖拽把手

编辑模式下（打开聊天或 ClickGUI）悬停 HUD 元素时，右下角出现一个把手，拖动即可缩放。此前只能「按住 zoom 键 + 滚轮」，没有任何视觉提示，发现性很差。

设计上的几个取舍：

| 决策 | 原因 |
|---|---|
| 把手固定 6px，**不随组件缩放** | 组件缩到 0.5x 时把手会小到点不中 |
| 组件小于 18×18 时**不显示把手** | 12×12 的命中区会吞掉小组件的大部分面积，让人没法再拖动位置 |
| 按**鼠标累计位移**算缩放，而非光标到原点的距离 | 右/下锚点的组件原点本身会随 scale 移动，用距离会反馈进下一帧的增量而跑飞 |
| 量化到 0.1 步长、钳在 [0.5, 4.5] | 与滚轮缩放走同一套边界，两条路径结果一致 |

拖 60px 约等于 1x。

## dragLock 改引用

`ComponentsManager.dragLock` 由 `String`（存 `mod.name`）改为 `Component` 引用 + `DragMode{MOVE, RESIZE}`：

- 每组件每帧一次字符串比较 → 引用比较
- 组件在找不到模块时会 fallback 造一个同名的临时 `InterfaceModule`（`Component.java` 构造器），两个组件同名时锁会串
- **修掉一个死锁边界情况**：「松开鼠标即解锁」原本写在**每个组件自己的 `display()` 里**，等于把一个全局事实重复判断 N 遍，且依赖至少有一个组件在渲染。拖拽途中若所有 HUD 组件恰好都不可见（比如快捷键关掉了模块），锁就永远留着，之后谁都拖不动——因为拿锁要求 `dragLock.isEmpty()`。现在上提到 `ComponentsManager.draw()` 每帧判一次

## 顺带

悬停标签的缩放显示 `(scale * 10) / 10f` 对 float 恒等于 `scale`，显示的是 `1.2999999x`。改为 `Math.round(scale * 10) / 10f`。

## 依赖说明

把手位置取决于当帧的 `width`/`height`，所以依赖 #168 的 `measure()` 阶段——否则把手会跟着尺寸变化漂移一帧，拖起来是飘的。同样地，#167 修好了 4 个组件的 scale 失效，否则那几个组件的把手拖了不会有反应。

🤖 Generated with [Claude Code](https://claude.com/claude-code)