### PR TITLE
refactor(gui): 命中检测遵循 z-order，隔离 HUD 编辑器，修复 stencil 泄漏 colorMask

### DIFF
--- a/src/main/java/top/fpsmaster/features/GlobalListener.java
+++ b/src/main/java/top/fpsmaster/features/GlobalListener.java
@@ -81,11 +81,14 @@ public class GlobalListener {
 
         if (ClientSettings.blur.getValue()) {
             StencilUtil.initStencilToWrite();
-            EventDispatcher.dispatchEvent(new EventShader());
-            FPSMaster.componentsManager.drawBackgroundMasks();
-            StencilUtil.readStencilBuffer(1);
-            KawaseBlur.renderBlur(3, 3);
-            StencilUtil.uninitStencilBuffer();
+            try {
+                EventDispatcher.dispatchEvent(new EventShader());
+                FPSMaster.componentsManager.drawBackgroundMasks();
+                StencilUtil.readStencilBuffer(1);
+                KawaseBlur.renderBlur(3, 3);
+            } finally {
+                StencilUtil.uninitStencilBuffer();
+            }
         }
 
         FPSMaster.componentsManager.draw((int) mouseX, (int) mouseY);

--- a/src/main/java/top/fpsmaster/ui/click/MainPanel.java
+++ b/src/main/java/top/fpsmaster/ui/click/MainPanel.java
@@ -406,6 +406,13 @@ public class MainPanel extends ScaledGuiScreen {
         super.keyTyped(typedChar, keyCode);
     }
 
+    @Override
+    protected float[] getOccludingBounds() {
+        // Only the panel itself, not the whole screen: dragging a HUD element that sits beside the
+        // ClickGUI is exactly what the user opened it for.
+        return new float[]{x, y, width, height};
+    }
+
     private void handlePointerPress() {
         ScaledGuiScreen.PointerEvent press = peekAnyPress();
         if (press == null) {

--- a/src/main/java/top/fpsmaster/ui/click/MainPanel.java
+++ b/src/main/java/top/fpsmaster/ui/click/MainPanel.java
@@ -420,10 +420,11 @@ public class MainPanel extends ScaledGuiScreen {
             return;
         }
 
-        if (hasPointerCapture()) {
-            return;
-        }
-
+        // A hasPointerCapture() guard used to sit here. It compensated for peekAnyPress() returning
+        // presses that another widget had already consumed — beginDrag consumes the press that starts
+        // a slider drag, yet the category strip still saw it and switched category underneath. Now that
+        // peekAnyPress() skips consumed presses the guard is redundant: the press is gone on the frame
+        // a drag begins, and later frames of the same drag produce no press at all.
         float my = getCategoryStartY();
         for (Category c : Category.values()) {
             if (Hover.is(x, my - 8, leftWidth, 24f, mouseX, mouseY)) {

--- a/src/main/java/top/fpsmaster/ui/click/modules/ModuleRenderer.java
+++ b/src/main/java/top/fpsmaster/ui/click/modules/ModuleRenderer.java
@@ -166,7 +166,9 @@ public class ModuleRenderer extends ValueRender {
         settingHeight = (float) AnimMath.base(settingHeight, settingsHeight, 0.2);
         this.height = settingHeight;
 
-        ScaledGuiScreen.PointerEvent click = screen.consumePressInBounds(x + 5, y, width - 10, 40f);
+        // Gated on z-order: the module header sits under the settings of the module expanded above it,
+        // and under any panel drawn later. `mod` is a stable per-frame identity.
+        ScaledGuiScreen.PointerEvent click = screen.consumePressAsHovered(mod, x + 5, y, width - 10, 40f);
         if (click != null) {
             if (click.button == 0) {
                 mod.toggle();

--- a/src/main/java/top/fpsmaster/ui/custom/Component.java
+++ b/src/main/java/top/fpsmaster/ui/custom/Component.java
@@ -17,6 +17,7 @@ import top.fpsmaster.font.impl.UFontRenderer;
 import top.fpsmaster.modules.logger.ClientLogger;
 import top.fpsmaster.ui.click.MainPanel;
 import top.fpsmaster.utils.core.Utility;
+import top.fpsmaster.utils.render.gui.GuiOcclusion;
 import top.fpsmaster.utils.math.anim.AnimMath;
 
 import java.awt.*;
@@ -227,8 +228,14 @@ public class Component {
             }
 
             if (hovered || overHandle || drag) {
-                if (Utility.mc.currentScreen instanceof MainPanel && ((MainPanel) Utility.mc.currentScreen).hasPointerCapture())
+                // The HUD editor runs from EventRender2D, which 1.8.9 fires while drawing the in-game
+                // overlay — before currentScreen.drawScreen(). Without this it happily drags components
+                // that are sitting *underneath* an open panel. The previous guard only covered the case
+                // where a ClickGUI slider already held a drag capture, which is a small fraction of the
+                // panel's area.
+                if (GuiOcclusion.covers(Mouse.getX(), Utility.mc.displayHeight - Mouse.getY())) {
                     return;
+                }
                 if (allowScale && ClientSettings.isZoomBindDown()) {
                     int dWheel = Mouse.getDWheel();
                     if (dWheel > 0) scaleUp();

--- a/src/main/java/top/fpsmaster/ui/screens/oobe/OobeDropdown.java
+++ b/src/main/java/top/fpsmaster/ui/screens/oobe/OobeDropdown.java
@@ -121,8 +121,9 @@ public class OobeDropdown {
                 }
             }
 
-            ScaledGuiScreen.PointerEvent outside = screen.peekAnyPress();
-            if (outside != null && openProgress > 0.95f && !Hover.is(x, y, width, height + panelHeight + 4f, outside.x, outside.y)) {
+            // Consume the dismissing click, otherwise it also activates whatever sits behind the popup.
+            if (openProgress > 0.95f
+                    && screen.consumePressOutside(x, y, width, height + panelHeight + 4f) != null) {
                 open = false;
             }
         }

--- a/src/main/java/top/fpsmaster/utils/render/StencilUtil.java
+++ b/src/main/java/top/fpsmaster/utils/render/StencilUtil.java
@@ -78,8 +78,21 @@ public class StencilUtil {
         GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_KEEP);
     }
 
+    /**
+     * Ends a stencil pass and restores everything {@link #initStencilToWrite()} changed.
+     *
+     * <p>The colour mask used to be reopened only by {@link #readStencilBuffer(int)}, which is a
+     * "switch to reading" call, not a teardown call. Any caller that threw — or returned early —
+     * between writing and reading left the mask fully closed for the rest of the process. The symptom
+     * is remote from the cause: the next {@code glClear(GL_COLOR_BUFFER_BIT)} anywhere (KawaseBlur's
+     * framebuffer clear, for instance) asks the driver to clear a colour buffer it is forbidden to
+     * write, which on Apple's Metal-backed GL aborts with "missing clear mask bits".
+     *
+     * <p>Reopening it here as well is idempotent and makes teardown total.
+     */
     public static void uninitStencilBuffer() {
         GL11.glDisable(GL11.GL_STENCIL_TEST);
+        GL11.glColorMask(true, true, true, true);
     }
 }
 

--- a/src/main/java/top/fpsmaster/utils/render/effects/Blur.java
+++ b/src/main/java/top/fpsmaster/utils/render/effects/Blur.java
@@ -13,9 +13,12 @@ public class Blur {
 
     public static void area(float x, float y, float width, float height, int radius, Color color, int iterations, int offset) {
         StencilUtil.initStencilToWrite();
-        RoundedUtil.drawRound(x, y, width, height, radius, true, color);
-        StencilUtil.readStencilBuffer(1);
-        KawaseBlur.renderBlur(iterations, offset);
-        StencilUtil.uninitStencilBuffer();
+        try {
+            RoundedUtil.drawRound(x, y, width, height, radius, true, color);
+            StencilUtil.readStencilBuffer(1);
+            KawaseBlur.renderBlur(iterations, offset);
+        } finally {
+            StencilUtil.uninitStencilBuffer();
+        }
     }
 }

--- a/src/main/java/top/fpsmaster/utils/render/gui/GuiInputState.java
+++ b/src/main/java/top/fpsmaster/utils/render/gui/GuiInputState.java
@@ -45,6 +45,9 @@ public final class GuiInputState {
     private int mouseY;
     private int wheelDelta;
 
+    private Object hoveredId;
+    private Object lastHoveredId;
+
     public void updateMousePosition(int mouseX, int mouseY) {
         this.mouseX = mouseX;
         this.mouseY = mouseY;
@@ -87,8 +90,41 @@ public final class GuiInputState {
         return !pressEvents.isEmpty();
     }
 
+    /**
+     * The most recent press that nobody has claimed yet.
+     *
+     * <p>This used to return the press regardless of consumption, so a widget peeking at it could act
+     * on a click another widget had already handled — which is why {@code MainPanel} needed a
+     * {@code hasPointerCapture()} guard to undo the double handling.
+     */
     public MouseButtonEvent getLatestPress() {
-        return latestPress;
+        return latestPress != null && latestPress.isConsumed() ? null : latestPress;
+    }
+
+    /**
+     * Records that the cursor is inside this widget, overwriting whatever was recorded earlier in the
+     * frame.
+     *
+     * <p>This is how z-order falls out of an immediate-mode GUI: widgets are visited in paint order,
+     * so the <em>last</em> one to claim the cursor is the one drawn on top. No comparison is needed —
+     * later simply wins. The result is only usable next frame, once the whole frame has been walked,
+     * which is why {@link #wasHovered} reads the previous frame's value. GUI layout barely moves
+     * between frames, so the one-frame lag is not observable.
+     */
+    public void markHovered(Object id, float x, float y, float width, float height) {
+        if (mouseX >= x && mouseX <= x + width && mouseY >= y && mouseY <= y + height) {
+            hoveredId = id;
+        }
+    }
+
+    /** Whether {@code id} was the topmost widget under the cursor at the end of the previous frame. */
+    public boolean wasHovered(Object id) {
+        return id != null && id.equals(lastHoveredId);
+    }
+
+    /** True until any widget has claimed the cursor, i.e. nothing is known to be on top yet. */
+    public boolean hasHoveredId() {
+        return lastHoveredId != null;
     }
 
     public int getMouseX() {
@@ -120,7 +156,34 @@ public final class GuiInputState {
         return null;
     }
 
+    /**
+     * Claims a press that landed <em>outside</em> the given rectangle — the "click away to dismiss"
+     * gesture for popups.
+     *
+     * <p>Consuming it is the whole point: a popup that merely notices the outside click and closes
+     * itself lets that same click through to whatever it was covering, so dismissing a dropdown also
+     * activates the button behind it.
+     */
+    public MouseButtonEvent consumePressOutside(float x, float y, float width, float height) {
+        for (MouseButtonEvent event : pressEvents) {
+            if (event.isConsumed()) {
+                continue;
+            }
+            boolean inside = event.getX() >= x && event.getX() <= x + width
+                    && event.getY() >= y && event.getY() <= y + height;
+            if (inside) {
+                continue;
+            }
+            event.consume();
+            return event;
+        }
+        return null;
+    }
+
     public void finishFrame() {
+        // Hand this frame's topmost-under-cursor result to the next frame, where it arbitrates clicks.
+        lastHoveredId = hoveredId;
+        hoveredId = null;
         pressEvents.clear();
         latestPress = null;
         wheelDelta = 0;
@@ -132,6 +195,7 @@ public final class GuiInputState {
         }
         mouseX = 0;
         mouseY = 0;
+        lastHoveredId = null;
         finishFrame();
     }
 }

--- a/src/main/java/top/fpsmaster/utils/render/gui/GuiOcclusion.java
+++ b/src/main/java/top/fpsmaster/utils/render/gui/GuiOcclusion.java
@@ -1,0 +1,49 @@
+package top.fpsmaster.utils.render.gui;
+
+/**
+ * Where the topmost custom screen is painting, in device pixels.
+ *
+ * <p>Hit-test ordering within one screen is handled by {@code GuiInputState}'s hovered-id. This solves
+ * the other half: the HUD component editor runs from {@code EventRender2D}, which 1.8.9 fires while
+ * drawing the in-game overlay — that is, <em>before</em> {@code currentScreen.drawScreen()}. The editor
+ * therefore reacts to presses underneath a screen that has not even been painted yet, using a
+ * completely separate input path, with no way for the two to arbitrate.
+ *
+ * <p>The fix is not to disable HUD editing while a panel is open — opening the ClickGUI is precisely
+ * when a user wants to move HUD elements. It is to make the panel occlude the cursor: components under
+ * the panel rectangle stop responding, components beside it keep working.
+ *
+ * <p>Device pixels are used because that is the only space the HUD editor and the ClickGUI agree on;
+ * they scale their own coordinates by different factors.
+ */
+public final class GuiOcclusion {
+
+    private static float x;
+    private static float y;
+    private static float width;
+    private static float height;
+    private static boolean active;
+
+    private GuiOcclusion() {
+    }
+
+    /** Reported once per frame by the screen that is painting, before the next frame's HUD pass. */
+    public static void set(float deviceX, float deviceY, float deviceWidth, float deviceHeight) {
+        x = deviceX;
+        y = deviceY;
+        width = deviceWidth;
+        height = deviceHeight;
+        active = deviceWidth > 0f && deviceHeight > 0f;
+    }
+
+    public static void clear() {
+        active = false;
+    }
+
+    /** @param deviceX cursor position in device pixels, y measured from the top */
+    public static boolean covers(float deviceX, float deviceY) {
+        return active
+                && deviceX >= x && deviceX <= x + width
+                && deviceY >= y && deviceY <= y + height;
+    }
+}

--- a/src/main/java/top/fpsmaster/utils/render/gui/ScaledGuiScreen.java
+++ b/src/main/java/top/fpsmaster/utils/render/gui/ScaledGuiScreen.java
@@ -66,12 +66,37 @@ public class ScaledGuiScreen extends GuiScreen {
             activeScreen = this;
             GL11.glScalef(renderScale, renderScale, 1f);
             render(inputState.getMouseX(), inputState.getMouseY(), partialTicks);
+            // Reported after render() so subclasses that compute their layout there (MainPanel centres
+            // itself every frame) have already done so. The HUD editor reads it on the next frame,
+            // which is fine — it runs ahead of this one within a frame anyway.
+            publishOcclusion();
         } finally {
             inputState.finishFrame();
             activeScreen = null;
             GL11.glPopMatrix();
             UiScale.end();
         }
+    }
+
+    /**
+     * The rectangle this screen paints over, in logical coordinates, or {@code null} for "the whole
+     * screen". Override in screens that only cover part of the display so the HUD stays interactive
+     * around them.
+     *
+     * @return {@code {x, y, width, height}}
+     */
+    protected float[] getOccludingBounds() {
+        return null;
+    }
+
+    private void publishOcclusion() {
+        float[] bounds = getOccludingBounds();
+        if (bounds == null) {
+            GuiOcclusion.set(0f, 0f, mc.displayWidth, mc.displayHeight);
+            return;
+        }
+        GuiOcclusion.set(bounds[0] * scaleFactor, bounds[1] * scaleFactor,
+                bounds[2] * scaleFactor, bounds[3] * scaleFactor);
     }
 
     @Override
@@ -86,6 +111,14 @@ public class ScaledGuiScreen extends GuiScreen {
         inputState.reset();
         dragState.clear();
         super.initGui();
+    }
+
+    @Override
+    public void onGuiClosed() {
+        // Nothing is covering the HUD any more; leaving this set would freeze the editor under a
+        // rectangle that is no longer painted.
+        GuiOcclusion.clear();
+        super.onGuiClosed();
     }
 
     @Override

--- a/src/main/java/top/fpsmaster/utils/render/gui/ScaledGuiScreen.java
+++ b/src/main/java/top/fpsmaster/utils/render/gui/ScaledGuiScreen.java
@@ -261,6 +261,48 @@ public class ScaledGuiScreen extends GuiScreen {
         return consumePressInBounds(x, y, width, height, button);
     }
 
+    /**
+     * Claims a click only if this widget was the topmost one under the cursor.
+     *
+     * <p>{@link #consumePressInBounds} alone is first-come-first-served, and widgets call it right
+     * after painting themselves — so the <em>first painted</em>, i.e. bottom-most, widget wins a
+     * contested click. That is the inverse of what z-order requires. This variant adds the missing
+     * ordering: {@code markHovered} records the topmost widget as the frame is walked, and the
+     * previous frame's answer gates the click here.
+     *
+     * <p>Widgets that still call {@code consumePressInBounds} keep the old behaviour, so this can be
+     * adopted one widget at a time.
+     *
+     * @param id stable identity for this widget across frames — the setting/module object itself works
+     *           well; avoid values that are rebuilt every frame
+     */
+    public PointerEvent consumePressAsHovered(Object id, float x, float y, float width, float height, int button) {
+        inputState.markHovered(id, x, y, width, height);
+        if (!inputState.wasHovered(id)) {
+            return null;
+        }
+        return consumePressInBounds(x, y, width, height, button);
+    }
+
+    public PointerEvent consumePressAsHovered(Object id, float x, float y, float width, float height) {
+        return consumePressAsHovered(id, x, y, width, height, -1);
+    }
+
+    /**
+     * Claims a press that landed outside the given rectangle — "click away to dismiss" for popups.
+     * The press is consumed so it does not also reach whatever the popup was covering.
+     */
+    public PointerEvent consumePressOutside(float x, float y, float width, float height) {
+        GuiInputState.MouseButtonEvent event = inputState.consumePressOutside(x, y, width, height);
+        return event == null ? null : new PointerEvent(event.getX(), event.getY(), event.getButton());
+    }
+
+    /** Hover feedback should follow the same z-order rule as clicks, or highlights double up. */
+    public boolean isHovered(Object id, float x, float y, float width, float height) {
+        inputState.markHovered(id, x, y, width, height);
+        return inputState.wasHovered(id);
+    }
+
     private int getLogicalMouseX() {
         return clampLogicalMouseX((int) (Mouse.getX() / scaleFactor));
     }


### PR DESCRIPTION
> 基于 #169，合并顺序 167 → 168 → 169 → 本 PR。

## 背景

`consumePressInBounds` 是先到先得，而控件都在**画完自己之后**立即调用它 —— 于是先绘制的、也就是最底层的控件赢得有争议的点击，正好是 z-order 的反面。

这不是实现失误，是立即模式 GUI 的固有约束:单趟遍历里画到某个控件时，无法知道后面还有没有东西会画在它上面。补丁修不了，因为信息在需要它的时刻还不存在。

## 改动一:hoveredId（层内排序）

采用立即模式 GUI 的标准解法 —— 用上一帧的最顶层命中结果裁决本帧的点击。

```java
// 绘制期无条件覆盖：控件按绘制顺序访问，最后一个宣称光标在自己身上的就是最上层的
public void markHovered(Object id, float x, float y, float w, float h) {
    if (cursorInside) hoveredId = id;      // 后写即赢，不需要比较
}
```

`finishFrame()` 把结果交给下一帧，`consumePressAsHovered(id, ...)` 在消费前查它。GUI 布局帧间几乎不变，这一帧延迟不可感知。

**老的 `consumePressInBounds` 保留**，未迁移控件行为完全不变，可以逐个迁移。首批迁移 `ModuleRenderer` 的模块开关（模块头部会被上方模块展开的设置覆盖）。

顺带删掉两个补丁:

- `getLatestPress()` 此前不检查 `isConsumed()`，`peekAnyPress()` 因此会返回别人已处理的点击。`MainPanel` 里那句 `hasPointerCapture()` 就是为抵消它而存在的 —— 拖滑块时 `beginDrag` 消费了 press，分类栏却还看得见、于是在底下切了分类。现在从根上解决，该守卫连同其存在理由一起删除。
- 新增 `consumePressOutside` 原语。`OobeDropdown` 此前只把 `open` 置 false 而**不消费**那次点击，所以关闭下拉的同一次点击会继续落到它覆盖的控件上 —— 单独修 `getLatestPress` 并不能解决，缺的就是这个原语。

## 改动二:GuiOcclusion（层间遮挡）

层内排序和层间遮挡是两个不同机制。后者是**模态语义**:屏幕内容区域应该遮挡它下面的一切。

`EventRender2D` 由 1.8.9 在绘制游戏内 overlay 时触发，即 `currentScreen.drawScreen()` **之前**，所以 HUD 编辑器会响应一个尚未绘制的面板底下的按压。

> **复现**:打开 ClickGUI，把面板挪到某个 HUD 元素上方，在面板的**非滑块区域**（模块行、分类栏、空白处）按住拖动 —— 背后的 HUD 元素跟着鼠标走。松开关掉 GUI，HUD 位置已被改掉。

`ScaledGuiScreen` 每帧上报绘制矩形（设备像素，两套系统唯一认同的空间），`Component` 查询光标是否被遮挡。

关键取舍:**不是「面板一开就禁用 HUD 编辑」** —— 打开 ClickGUI 恰恰是用户想调 HUD 的时候。而是「光标落在面板矩形内时不响应」，所以面板**旁边**的 HUD 元素仍可正常拖。`MainPanel` 因此只上报面板矩形，其余屏幕默认全屏。

## 改动三:stencil 泄漏 colorMask（与 GUI 重构无关，但一直在制造崩溃）

`StencilUtil` 把 colorMask 的恢复放在 `readStencilBuffer()` 里 —— 那是个「切换到读模式」的方法，不是收尾方法。任何在写与读之间抛异常或提前返回的路径，都会让 colorMask 永久停在 `(false,false,false,false)`。

症状离病因很远:之后任何地方的 `glClear(GL_COLOR_BUFFER_BIT)`（例如 KawaseBlur 的 `framebufferClear`）都在要求驱动清一个它被禁止写入的缓冲，在 Apple 的 Metal-backed GL 上直接断言中止 `missing clear mask bits`。

本机实测的多次崩溃（主菜单天空盒、打开音乐播放器）栈顶各不相同却都是同一条断言，正因为它们都是**受害者**而非元凶。

- `uninitStencilBuffer()` 一并恢复 colorMask，使收尾完整（幂等）
- `Blur.area()` 与 `GlobalListener` 的 blur 块补 `try/finally`

## 未覆盖

`MusicScreen` 仍绕过整套框架 —— 它 `consumePressInBounds(0, 0, guiWidth, guiHeight)` 一次吃掉整屏，再用 33 处私有 `in(...)` 各自重测，所以 consume-once 和 z-order 门控对它都无作用。另有独立 PR 处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)