### PR TITLE
fix(font): 修复 betterFont下自定义计分板文字透明不可见

### DIFF
--- a/src/main/java/top/fpsmaster/font/impl/UFontRenderer.java
+++ b/src/main/java/top/fpsmaster/font/impl/UFontRenderer.java
@@ -172,6 +172,14 @@ public class UFontRenderer extends FontRenderer {
     }
 
     private int edge$drawStringInternal(String text, float x, float y, int color, boolean dropShadow, float shadowOffset) {
+        // Vanilla treats a colour with no alpha bits as opaque — its drawString does
+        // `if ((color & 0xFC000000) == 0) color |= 0xFF000000` and the custom-font mixin keeps
+        // the rule for the vanilla-replacement path. Without it here, callers that pass opaque
+        // colours the vanilla way (the custom scoreboard passes 0xFFFFFF) draw fully transparent
+        // once routed through this renderer.
+        if ((color & 0xFC000000) == 0) {
+            color |= 0xFF000000;
+        }
         color = apply(color);
         int i;
         if (dropShadow) {

--- a/src/main/java/top/fpsmaster/font/impl/UFontRenderer.java
+++ b/src/main/java/top/fpsmaster/font/impl/UFontRenderer.java
@@ -176,7 +176,15 @@ public class UFontRenderer extends FontRenderer {
         // `if ((color & 0xFC000000) == 0) color |= 0xFF000000` and the custom-font mixin keeps
         // the rule for the vanilla-replacement path. Without it here, callers that pass opaque
         // colours the vanilla way (the custom scoreboard passes 0xFFFFFF) draw fully transparent
-        // once routed through this renderer.
+        // once routed through this renderer. This class extends FontRenderer and is handed around
+        // as one — LevelTag picks between it and fontRendererObj at runtime — so a vanilla-shaped
+        // colour has to mean what it means everywhere else.
+        //
+        // The cost is that alpha 1-3 can no longer be asked for: a caller fading its own text out
+        // must stop above three rather than run to zero, which is what MixinGuiNewChat, the OOBE
+        // screen and every other fade in the client do. The global fade is unaffected — Alpha.apply
+        // runs after this, so Alpha.set(0f) still reaches zero and stays invisible. Do not move
+        // this below that call; a0860d7 removed the rule from TextRenderer for exactly that reason.
         if ((color & 0xFC000000) == 0) {
             color |= 0xFF000000;
         }

--- a/src/main/java/top/fpsmaster/ui/custom/Component.java
+++ b/src/main/java/top/fpsmaster/ui/custom/Component.java
@@ -406,7 +406,22 @@ public class Component {
         drawString(fontSize, false, text, x, y, color);
     }
 
+    /**
+     * Draws a component's text.
+     *
+     * <p>Colours here come from {@link top.fpsmaster.features.settings.impl.ColorSetting}, whose
+     * alpha slider reaches zero and whose Wave mode scales what it returns, so alpha means what it
+     * says: below four there is nothing to draw. Both renderers underneath read it vanilla's way
+     * instead — no alpha bits set means opaque — and would turn a string the user hid into a solid
+     * one. Components must therefore pass a real alpha, not a bare {@code 0xRRGGBB}.
+     *
+     * <p>Only text is affected. Backgrounds and shapes go through {@code drawRect} and {@code Rects}
+     * and never come through here, so a fully transparent background stays transparent.
+     */
     public void drawString(int fontSize, boolean bold, String text, float x, float y, int color) {
+        if (((color >>> 24) & 0xFF) <= 3) {
+            return;
+        }
         double scaled = (int) (scale * 100) / 100.0;
         fontSize = (int) (fontSize * scale);
         UFontRenderer font = FPSMaster.fontManager.getFont(fontSize);

--- a/src/main/java/top/fpsmaster/ui/custom/impl/ScoreboardComponent.java
+++ b/src/main/java/top/fpsmaster/ui/custom/impl/ScoreboardComponent.java
@@ -66,11 +66,13 @@ public class ScoreboardComponent extends Component {
         width = maxWidth + 6;
         height = (lines.size() + 1) * lineHeight + 4;
         drawRect(x, y, width, height, mod.backgroundColor.getColor());
-        drawString(FONT_SIZE, title, x + 3 * scale, y + 2 * scale, 0xFFFFFF);
+        // Opaque white as -1, the way every other component writes it. A bare 0xFFFFFF is vanilla's
+        // spelling of the same colour, and Component.drawString does not read alpha vanilla's way.
+        drawString(FONT_SIZE, title, x + 3 * scale, y + 2 * scale, -1);
         // Row offsets are positions, so they scale here.
         float offsetY = y + (2 + lineHeight) * scale;
         for (String line : lines) {
-            drawString(FONT_SIZE, line, x + 3 * scale, offsetY, 0xFFFFFF);
+            drawString(FONT_SIZE, line, x + 3 * scale, offsetY, -1);
             offsetY += lineHeight * scale;
         }
     }

--- a/src/main/java/top/fpsmaster/ui/screens/oobe/OobeScreen.java
+++ b/src/main/java/top/fpsmaster/ui/screens/oobe/OobeScreen.java
@@ -372,11 +372,17 @@ public class OobeScreen extends ScaledGuiScreen {
         Color titleColor = new Color(24, 32, 54, alpha);
         Color descColor = new Color(92, 101, 118, alpha);
 
-        GL11.glPushMatrix();
-        GL11.glTranslatef(0f, (1f - tutorialSlideTransition) * 8f, 0f);
-        FPSMaster.fontManager.s18.drawString(slides[tutorialIndex][0], x + 24f, cardY + 54f, titleColor.getRGB());
-        drawMultilineBodyTextWithAlpha(extendTutorialDescription(slides[tutorialIndex][1], tutorialIndex), x + 24f, cardY + 94f, width - 48f, 4, alpha);
-        GL11.glPopMatrix();
+        // Below four the renderer reads the colour as vanilla does - no alpha bits set means opaque -
+        // so a fade this shallow comes out solid rather than invisible. updateTutorialAutoplay resets
+        // the transition after updateAnimations has advanced it, which puts the frame a slide flips on
+        // at exactly zero: without this the new slide pops in at full opacity before its fade starts.
+        if (alpha > 3) {
+            GL11.glPushMatrix();
+            GL11.glTranslatef(0f, (1f - tutorialSlideTransition) * 8f, 0f);
+            FPSMaster.fontManager.s18.drawString(slides[tutorialIndex][0], x + 24f, cardY + 54f, titleColor.getRGB());
+            drawMultilineBodyTextWithAlpha(extendTutorialDescription(slides[tutorialIndex][1], tutorialIndex), x + 24f, cardY + 94f, width - 48f, 4, alpha);
+            GL11.glPopMatrix();
+        }
     }
 
     private void renderFeaturesPage() {
@@ -987,14 +993,23 @@ public class OobeScreen extends ScaledGuiScreen {
         int currentAlpha = Math.min(255, Math.max(0, Math.round(eased * 255f)));
         Color currentColor = new Color(accentText().getRed(), accentText().getGreen(), accentText().getBlue(), currentAlpha);
 
+        // Both passes stop at four rather than zero: the renderer reads a colour with no alpha bits
+        // as opaque, the way vanilla's does, so anything below that comes out solid. The fade-out is
+        // the one that matters - it is cubic, so previousAlpha sits in that band for the last 30-odd
+        // frames of the half-second crossfade, and the outgoing greeting would hold full opacity
+        // there and then vanish. Neither pass has anything left to show by four.
         if (greetingTransition < 1f && greetingPreviousText != null && !greetingPreviousText.isEmpty()) {
             float previousProgress = 1f - eased;
             int previousAlpha = Math.min(255, Math.max(0, Math.round(previousProgress * 255f)));
-            Color previousColor = new Color(accentText().getRed(), accentText().getGreen(), accentText().getBlue(), previousAlpha);
-            FPSMaster.fontManager.s18.drawString(greetingPreviousText, x, y - eased * 8f, previousColor.getRGB());
+            if (previousAlpha > 3) {
+                Color previousColor = new Color(accentText().getRed(), accentText().getGreen(), accentText().getBlue(), previousAlpha);
+                FPSMaster.fontManager.s18.drawString(greetingPreviousText, x, y - eased * 8f, previousColor.getRGB());
+            }
         }
 
-        FPSMaster.fontManager.s18.drawString(greetingCurrentText, x, y + (1f - eased) * 8f, currentColor.getRGB());
+        if (currentAlpha > 3) {
+            FPSMaster.fontManager.s18.drawString(greetingCurrentText, x, y + (1f - eased) * 8f, currentColor.getRGB());
+        }
     }
 
     private void switchLanguage(int newLanguage) {


### PR DESCRIPTION
  根因：UFontRenderer.drawString 没有像 vanilla FontRenderer 那样把「无 alpha 位的颜色」强制为不透明（vanilla
  规则：if ((color & 0xFC000000) == 0) color |= 0xFF000000）。自定义计分板以 0xFFFFFF
  传色（ScoreboardComponent.java:69,73），经 betterFont 路径 Alpha.apply 后 alpha 仍为 0，TextRenderer
  把所有四边形的 alpha 写成 0 → 文字全透明。而计分板背景默认是透明黑，所以整块「消失」。其他 HUD 都传 -1
  或带显式 alpha，所以只有计分板中招。