### PR TITLE
fix(ui): guard server ping loop against netty NPE crash (#179)

### DIFF
--- a/src/main/java/top/fpsmaster/ui/mc/GuiMultiplayer.java
+++ b/src/main/java/top/fpsmaster/ui/mc/GuiMultiplayer.java
@@ -214,7 +214,15 @@ public class GuiMultiplayer extends ScaledGuiScreen {
         super.updateScreen();
         // Forge's FMLClientHandler.setupServerList() only wires LAN/Realms discovery, which this
         // custom multiplayer screen does not use; the vanilla ping loop below is all we need.
-        this.oldServerPinger.pingPendingNetworks();
+        // Guard the ping loop: OldServerPinger's legacy-ping fallback can surface a netty NPE
+        // (Bootstrap.checkAddress with a null address) on the tick thread when a server entry
+        // fails to resolve, which would otherwise crash the whole client (issue #179). A single
+        // bad server ping must never take down the screen.
+        try {
+            this.oldServerPinger.pingPendingNetworks();
+        } catch (Throwable t) {
+            logger.error("Couldn't ping pending server networks", t);
+        }
     }
 
     @Override


### PR DESCRIPTION
## 问题

Issue #179：进入多人游戏服务器列表页面后客户端崩溃（`Ticking screen` / `NullPointerException`）。

## 根因

vanilla `OldServerPinger` 的旧版-ping 回退路径在服务器地址解析失败时，会把 `null` 地址传给 netty `Bootstrap.connect`，`checkAddress` 抛 NPE。该异常在 `GuiMultiplayer.updateScreen → pingPendingNetworks()` 的 tick 线程上冒泡，导致整个客户端硬崩（典型触发：ViaForge + 一个不可达的服务器条目）。

## 修复

给 `pingPendingNetworks()` 包一层 `try/catch(Throwable)`，单个服务器 ping 出错只记日志、不再崩掉整个界面。另一处初始 `ping()`（`ServerListEntry`）本就在后台线程且已被 try/catch 保护，无需改动。

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)